### PR TITLE
ENTERPRISE-19; cnange addon groupId to match one registered on Atlassian

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <groupId>org.eclipse.che.parent</groupId>
         <version>5.0.0-M3</version>
     </parent>
-    <groupId>com.codenvy.plugin</groupId>
+    <groupId>com.codenvy.jira</groupId>
     <artifactId>codenvy-jira-plugin</artifactId>
     <version>1.0.5-SNAPSHOT</version>
     <packaging>atlassian-plugin</packaging>

--- a/src/aps/log4j.properties
+++ b/src/aps/log4j.properties
@@ -560,5 +560,5 @@ log4j.additivity.com.atlassian.plugin.remotable.plugin.service.LocalSignedReques
 log4j.logger.com.atlassian.plugin.remotable.host.common.service.http.bigpipe.DefaultBigPipeManager = INFO, console, remoteappssecurity
 log4j.additivity.com.atlassian.plugin.remotable.host.common.service.http.bigpipe.DefaultBigPipeManager = false
 
-log4j.logger.com.codenvy.plugin = DEBUG, console, filelog
-log4j.additivity.com.codenvy.plugin = false
+log4j.logger.com.codenvy.jira = DEBUG, console, filelog
+log4j.additivity.com.codenvy.jira = false

--- a/src/main/java/com/codenvy/jira/CodenvyPluginComponent.java
+++ b/src/main/java/com/codenvy/jira/CodenvyPluginComponent.java
@@ -8,32 +8,18 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package com.codenvy.plugin;
-
-import com.atlassian.sal.api.ApplicationProperties;
+package com.codenvy.jira;
 
 /**
- * Implementation of {@link com.codenvy.plugin.CodenvyPluginComponent}
+ * Plugin component module
  *
  * @author Stephane Tournie
  */
-public class CodenvyPluginComponentImpl implements CodenvyPluginComponent {
-    private final ApplicationProperties applicationProperties;
-
-    public CodenvyPluginComponentImpl(ApplicationProperties applicationProperties) {
-        this.applicationProperties = applicationProperties;
-    }
-
+public interface CodenvyPluginComponent {
     /**
      * Get the name of the component
      *
      * @return the name of the component
      */
-    public String getName() {
-        if (null != applicationProperties) {
-            return "codenvyPluginComponent:" + applicationProperties.getDisplayName();
-        }
-
-        return "codenvyPluginComponent";
-    }
+    String getName();
 }

--- a/src/main/java/com/codenvy/jira/CodenvyPluginComponentImpl.java
+++ b/src/main/java/com/codenvy/jira/CodenvyPluginComponentImpl.java
@@ -8,18 +8,32 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package com.codenvy.plugin;
+package com.codenvy.jira;
+
+import com.atlassian.sal.api.ApplicationProperties;
 
 /**
- * Plugin component module
+ * Implementation of {@link com.codenvy.jira.CodenvyPluginComponent}
  *
  * @author Stephane Tournie
  */
-public interface CodenvyPluginComponent {
+public class CodenvyPluginComponentImpl implements CodenvyPluginComponent {
+    private final ApplicationProperties applicationProperties;
+
+    public CodenvyPluginComponentImpl(ApplicationProperties applicationProperties) {
+        this.applicationProperties = applicationProperties;
+    }
+
     /**
      * Get the name of the component
      *
      * @return the name of the component
      */
-    String getName();
+    public String getName() {
+        if (null != applicationProperties) {
+            return "codenvyPluginComponent:" + applicationProperties.getDisplayName();
+        }
+
+        return "codenvyPluginComponent";
+    }
 }

--- a/src/main/java/com/codenvy/jira/IssueCreatedListener.java
+++ b/src/main/java/com/codenvy/jira/IssueCreatedListener.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package com.codenvy.plugin;
+package com.codenvy.jira;
 
 import us.monoid.json.JSONArray;
 import us.monoid.json.JSONException;
@@ -49,8 +49,8 @@ public class IssueCreatedListener implements InitializingBean, DisposableBean {
 
     private static final Logger LOG = LoggerFactory.getLogger(IssueCreatedListener.class);
 
-    private static final String CODENVY_DEVELOP_FIELD_TYPE_KEY = "com.codenvy.plugin.codenvy-jira-plugin:developfield";
-    private static final String CODENVY_REVIEW_FIELD_TYPE_KEY  = "com.codenvy.plugin.codenvy-jira-plugin:reviewfield";
+    private static final String CODENVY_DEVELOP_FIELD_TYPE_KEY = "com.codenvy.jira.codenvy-jira-plugin:developfield";
+    private static final String CODENVY_REVIEW_FIELD_TYPE_KEY  = "com.codenvy.jira.codenvy-jira-plugin:reviewfield";
 
     private final EventPublisher        eventPublisher;
     private final PluginSettingsFactory pluginSettingsFactory;

--- a/src/main/java/com/codenvy/jira/administrate/AdminServlet.java
+++ b/src/main/java/com/codenvy/jira/administrate/AdminServlet.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package com.codenvy.plugin.administrate;
+package com.codenvy.jira.administrate;
 
 import java.io.IOException;
 

--- a/src/main/java/com/codenvy/jira/administrate/ConfigResource.java
+++ b/src/main/java/com/codenvy/jira/administrate/ConfigResource.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package com.codenvy.plugin.administrate;
+package com.codenvy.jira.administrate;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;

--- a/src/main/java/com/codenvy/jira/customfield/DevelopCustomField.java
+++ b/src/main/java/com/codenvy/jira/customfield/DevelopCustomField.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package com.codenvy.plugin.customfield;
+package com.codenvy.jira.customfield;
 
 import com.atlassian.jira.issue.customfields.impl.GenericTextCFType;
 import com.atlassian.jira.issue.customfields.manager.GenericConfigManager;
@@ -17,11 +17,11 @@ import com.atlassian.jira.issue.fields.TextFieldCharacterLengthValidator;
 import com.atlassian.jira.security.JiraAuthenticationContext;
 
 
-public class ReviewCustomField extends GenericTextCFType {
+public class DevelopCustomField extends GenericTextCFType {
 
-    public ReviewCustomField(CustomFieldValuePersister customFieldValuePersister, GenericConfigManager genericConfigManager,
-                             TextFieldCharacterLengthValidator textFieldCharacterLengthValidator,
-                             JiraAuthenticationContext jiraAuthenticationContext) {
+    public DevelopCustomField(CustomFieldValuePersister customFieldValuePersister, GenericConfigManager genericConfigManager,
+                              TextFieldCharacterLengthValidator textFieldCharacterLengthValidator,
+                              JiraAuthenticationContext jiraAuthenticationContext) {
 
         super(customFieldValuePersister, genericConfigManager, textFieldCharacterLengthValidator, jiraAuthenticationContext);
     }

--- a/src/main/java/com/codenvy/jira/customfield/ReviewCustomField.java
+++ b/src/main/java/com/codenvy/jira/customfield/ReviewCustomField.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package com.codenvy.plugin.customfield;
+package com.codenvy.jira.customfield;
 
 import com.atlassian.jira.issue.customfields.impl.GenericTextCFType;
 import com.atlassian.jira.issue.customfields.manager.GenericConfigManager;
@@ -17,11 +17,11 @@ import com.atlassian.jira.issue.fields.TextFieldCharacterLengthValidator;
 import com.atlassian.jira.security.JiraAuthenticationContext;
 
 
-public class DevelopCustomField extends GenericTextCFType {
+public class ReviewCustomField extends GenericTextCFType {
 
-    public DevelopCustomField(CustomFieldValuePersister customFieldValuePersister, GenericConfigManager genericConfigManager,
-                              TextFieldCharacterLengthValidator textFieldCharacterLengthValidator,
-                              JiraAuthenticationContext jiraAuthenticationContext) {
+    public ReviewCustomField(CustomFieldValuePersister customFieldValuePersister, GenericConfigManager genericConfigManager,
+                             TextFieldCharacterLengthValidator textFieldCharacterLengthValidator,
+                             JiraAuthenticationContext jiraAuthenticationContext) {
 
         super(customFieldValuePersister, genericConfigManager, textFieldCharacterLengthValidator, jiraAuthenticationContext);
     }

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -23,15 +23,15 @@
     <resource type="i18n" name="i18n" location="codenvy-jira-plugin"/>
     
     <!-- publish our component -->
-    <component key="codenvyPluginComponent" class="com.codenvy.plugin.CodenvyPluginComponentImpl" public="true">
-        <interface>com.codenvy.plugin.CodenvyPluginComponent</interface>
+    <component key="codenvyPluginComponent" class="com.codenvy.jira.CodenvyPluginComponentImpl" public="true">
+        <interface>com.codenvy.jira.CodenvyPluginComponent</interface>
     </component>
     
     <!-- import from the product container -->
     <component-import key="applicationProperties" interface="com.atlassian.sal.api.ApplicationProperties" />
 
     <component-import key="eventPublisher" interface="com.atlassian.event.api.EventPublisher"/>
-    <component key="eventListener" class="com.codenvy.plugin.IssueCreatedListener">
+    <component key="eventListener" class="com.codenvy.jira.IssueCreatedListener">
         <description>Class that generates a Codenvy factory when a new factory enabled issue is created.</description>
     </component>
 
@@ -44,7 +44,7 @@
     <component-import key="fieldManager" interface="com.atlassian.jira.issue.fields.FieldManager" />
 
     <!-- Add-on admin resources -->
-    <servlet key="admin-servlet" class="com.codenvy.plugin.administrate.AdminServlet">
+    <servlet key="admin-servlet" class="com.codenvy.jira.administrate.AdminServlet">
         <url-pattern>/codenvy/admin</url-pattern>
     </servlet>
     <rest key="rest" path="/codenvy-admin" version="1.0">
@@ -64,7 +64,7 @@
 
     <!-- Develop custom field type -->
     <customfield-type key="developfield" name="Codenvy Develop Field"
-                      class="com.codenvy.plugin.customfield.DevelopCustomField">
+                      class="com.codenvy.jira.customfield.DevelopCustomField">
         <description>Open your Codenvy workspace in one click.</description>
         <resource type="velocity" name="view" location="templates/view-codenvy-field.vm"/>
         <resource type="velocity" name="edit" location="templates/edit-codenvy-field.vm"/>
@@ -73,7 +73,7 @@
 
     <!-- Review custom field type -->
     <customfield-type key="reviewfield" name="Codenvy Review Field"
-                      class="com.codenvy.plugin.customfield.ReviewCustomField">
+                      class="com.codenvy.jira.customfield.ReviewCustomField">
         <description>Open a per click Codenvy workspace in one click.</description>
         <resource type="velocity" name="view" location="templates/view-codenvy-field.vm"/>
         <resource type="velocity" name="edit" location="templates/edit-codenvy-field.vm"/>

--- a/src/main/resources/templates/admin.vm
+++ b/src/main/resources/templates/admin.vm
@@ -13,7 +13,7 @@
 <head>
     <title>Codenvy Administration</title>
     <meta name="decorator" content="atl.admin">
-    $webResourceManager.requireResource("com.codenvy.plugin.codenvy-jira-plugin:resources")
+    $webResourceManager.requireResource("com.codenvy.jira.codenvy-jira-plugin:resources")
 </head>
 <body>
 <form id="admin" class="aui">

--- a/src/test/java/it/com/codenvy/jira/CodenvyComponentWiredTest.java
+++ b/src/test/java/it/com/codenvy/jira/CodenvyComponentWiredTest.java
@@ -8,14 +8,14 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package it.com.codenvy.plugin;
+package it.com.codenvy.jira;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.atlassian.plugins.osgi.test.AtlassianPluginsTestRunner;
 import com.atlassian.sal.api.ApplicationProperties;
-import com.codenvy.plugin.CodenvyPluginComponent;
+import com.codenvy.jira.CodenvyPluginComponent;
 
 import static org.junit.Assert.assertEquals;
 

--- a/src/test/java/ut/com/codenvy/jira/CodenvyPluginComponentUnitTest.java
+++ b/src/test/java/ut/com/codenvy/jira/CodenvyPluginComponentUnitTest.java
@@ -8,12 +8,12 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package ut.com.codenvy.plugin;
+package ut.com.codenvy.jira;
 
 import org.junit.Test;
 
-import com.codenvy.plugin.CodenvyPluginComponent;
-import com.codenvy.plugin.CodenvyPluginComponentImpl;
+import com.codenvy.jira.CodenvyPluginComponent;
+import com.codenvy.jira.CodenvyPluginComponentImpl;
 
 import static org.junit.Assert.assertEquals;
 

--- a/src/test/java/ut/com/codenvy/jira/IssueCreatedListenerUnitTest.java
+++ b/src/test/java/ut/com/codenvy/jira/IssueCreatedListenerUnitTest.java
@@ -8,12 +8,11 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package ut.com.codenvy.plugin;
+package ut.com.codenvy.jira;
 
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 
-import com.atlassian.crowd.embedded.api.User;
 import com.atlassian.event.api.EventPublisher;
 import com.atlassian.jira.bc.issue.IssueService;
 import com.atlassian.jira.event.issue.IssueEvent;
@@ -28,7 +27,7 @@ import com.atlassian.jira.user.ApplicationUser;
 import com.atlassian.jira.util.ErrorCollection;
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
-import com.codenvy.plugin.IssueCreatedListener;
+import com.codenvy.jira.IssueCreatedListener;
 
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
Cnange addon groupId to match one registered on Atlassian, this allows descriptor to be:

```
<atlassian-plugin key="com.codenvy.jira.codenvy-jira-plugin" name="Codenvy JIRA Plugin" plugins-version="2">
```

Fixes https://github.com/codenvy/enterprise/issues/19